### PR TITLE
frontender: HTTPS frontender-->backend proxy implemented

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -174,28 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/example_test.go
+++ b/example_test.go
@@ -1,13 +1,17 @@
-# frontender
-Setup a server frontend with HTTPS that then proxies to traffic to a backend/cluster.
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-This project is used inside orijtech to create for folks HTTPS servers that can then be
-put in Docker images, or automatically uploaded to respective cloud storage systems
-and passed into some container engine for a disk image.
-
-## Examples:
-* Preamble with imports:
-```go
 package frontender_test
 
 import (
@@ -17,11 +21,8 @@ import (
 
 	"github.com/orijtech/frontender"
 )
-```
 
-* Plain listen as a server:
-```go
-func listen() {
+func Example_Listen() {
 	lc, err := frontender.Listen(&frontender.Request{
 		Domains: []string{
 			"git.orijtech.com",
@@ -42,11 +43,8 @@ func listen() {
 		log.Fatal(err)
 	}
 }
-```
 
-* Generate the binary of the server for a platform
-```go
-func generateBinary() {
+func Example_GenerateBinary() {
 	rc, err := frontender.GenerateBinary(&frontender.DeployInfo{
 		FrontendConfig: &frontender.Request{
 			Domains: []string{
@@ -72,11 +70,8 @@ func generateBinary() {
 
 	io.Copy(f, rc)
 }
-```
 
-* Generate a Docker image for the server
-```go
-func generateDockerImage() {
+func Example_GenerateDockerImage() {
 	imageName, err := frontender.GenerateDockerImage(&frontender.DeployInfo{
 		CanonicalImageNamePrefix: "frontender",
 		FrontendConfig: &frontender.Request{
@@ -97,4 +92,3 @@ func generateDockerImage() {
 	}
 	log.Printf("ImageName: %q\n", imageName)
 }
-```

--- a/frontender.go
+++ b/frontender.go
@@ -1,0 +1,209 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontender
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/acme/autocert"
+
+	"github.com/orijtech/otils"
+)
+
+type Request struct {
+	// HTTP1 signifies that this server should
+	// not be ran as an HTTP/2<-->HTTPS server.
+	// This variable is useful for testing purposes.
+	HTTP1 bool `json:"http1"`
+
+	Domains []string `json:"domains"`
+
+	NoAutoWWW bool `json:"no_auto_www"`
+
+	ProxyAddress string `json:"proxy_address"`
+
+	NonHTTPSRedirectURL string `json:"non_https_redirect_url"`
+	NonHTTPSAddr        string `json:"non_https_addr"`
+
+	DomainsListener func(domains ...string) net.Listener
+
+	Environ    []string `json:"environ"`
+	TargetGOOS string   `json:"target_goos"`
+}
+
+var (
+	errEmptyDomains  = errors.New("expecting at least one non-empty domain")
+	errAlreadyClosed = errors.New("already closed")
+
+	errEmptyProxyAddress = errors.New("expecting a non-empty proxy server address")
+)
+
+func (req *Request) Validate() error {
+	if req == nil || strings.TrimSpace(req.ProxyAddress) == "" {
+		return errEmptyProxyAddress
+	}
+	if req.needsDomains() && strings.TrimSpace(otils.FirstNonEmptyString(req.Domains...)) == "" {
+		return errEmptyDomains
+	}
+	return nil
+}
+
+type Server struct {
+	Domains []string `json:"domains"`
+
+	ProxyAddress string `json:"proxy_address"`
+
+	NonHTTPSRedirectURL string `json:"non_https_redirect_url"`
+}
+
+// Synthesizes domains removing duplicates
+// and if NoAutoWWW if not set, will automatically make
+// the corresponding www.domain domain.
+func (req *Request) SynthesizeDomains() []string {
+	var finalList []string
+	uniqs := make(map[string]bool)
+	for _, domain := range req.Domains {
+		domain = strings.TrimSpace(domain)
+		if domain == "" {
+			continue
+		}
+
+		toAdd := []string{domain}
+		if !req.NoAutoWWW && !strings.HasPrefix(domain, "www") {
+			toAdd = append(toAdd, fmt.Sprintf("www.%s", domain))
+		}
+
+		for _, curDomain := range toAdd {
+			if _, seen := uniqs[curDomain]; seen {
+				continue
+			}
+
+			finalList = append(finalList, curDomain)
+			uniqs[curDomain] = true
+		}
+	}
+
+	return finalList
+}
+
+type proxy struct {
+	proxyAddress string
+}
+
+func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, p.proxyAddress, http.StatusPermanentRedirect)
+}
+
+var _ http.Handler = (*proxy)(nil)
+
+func (req *Request) runNonHTTPSRedirector() error {
+	if req.HTTP1 {
+		return nil
+	}
+
+	redirectURL := strings.TrimSpace(req.NonHTTPSRedirectURL)
+	if redirectURL == "" {
+		return nil
+	}
+	nonHTTPSAddr := strings.TrimSpace(req.NonHTTPSAddr)
+	if nonHTTPSAddr == "" {
+		nonHTTPSAddr = ":80"
+	}
+
+	return http.ListenAndServe(nonHTTPSAddr, otils.RedirectAllTrafficTo(redirectURL))
+}
+
+type ListenConfirmation struct {
+	closeFn  func() error
+	errsChan <-chan error
+}
+
+func (lc *ListenConfirmation) Close() error {
+	return lc.closeFn()
+}
+
+func (lc *ListenConfirmation) Wait() error {
+	return <-lc.errsChan
+}
+
+func (req *Request) needsDomains() bool {
+	return req.HTTP1 == false
+}
+
+func Listen(req *Request) (*ListenConfirmation, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	proxyURL, err := url.Parse(req.ProxyAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	madeDomains := req.SynthesizeDomains()
+	if req.needsDomains() && len(madeDomains) == 0 {
+		return nil, errEmptyDomains
+	}
+
+	domainsListener := req.DomainsListener
+	if domainsListener == nil {
+		if !req.HTTP1 {
+			domainsListener = autocert.NewListener
+		} else {
+			listener, err := net.Listen("tcp", ":80")
+			if err != nil {
+				return nil, err
+			}
+			domainsListener = func(domains ...string) net.Listener { return listener }
+		}
+	}
+	listener := domainsListener(madeDomains...)
+
+	return req.runAndCreateListener(listener, proxyURL)
+}
+
+func (req *Request) runAndCreateListener(listener net.Listener, proxyURL *url.URL) (*ListenConfirmation, error) {
+	var closeOnce sync.Once
+	errsChan := make(chan error)
+	closeFn := func() error {
+		err := errAlreadyClosed
+		closeOnce.Do(func() {
+			err = listener.Close()
+		})
+		return err
+	}
+
+	lc := &ListenConfirmation{closeFn: closeFn, errsChan: errsChan}
+
+	// Run the nonHTTPS redirector.
+	go req.runNonHTTPSRedirector()
+
+	// Now run the domain listener
+	go func() {
+		defer close(errsChan)
+
+		proxy := httputil.NewSingleHostReverseProxy(proxyURL)
+		errsChan <- http.Serve(listener, proxy)
+	}()
+
+	return lc, nil
+}

--- a/frontender_test.go
+++ b/frontender_test.go
@@ -1,0 +1,184 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontender_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/orijtech/frontender"
+)
+
+func TestListen(t *testing.T) {
+	t.Skipf("Tests not fully backed")
+
+	theLog := new(bytes.Buffer)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(theLog, "Now here from: %q\n", req.URL)
+	}))
+	defer ts.Close()
+
+	nonHTTPSBackend := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(theLog, "first redirected from %q\n", req.URL)
+		http.Redirect(rw, req, ts.URL, http.StatusPermanentRedirect)
+	}))
+	defer nonHTTPSBackend.Close()
+
+	domainsListener := func(domains ...string) net.Listener {
+		return ts.Listener
+	}
+
+	lc, err := frontender.Listen(&frontender.Request{
+		Domains: []string{
+			"git.orijtech.com",
+			"repo.orijtech.com",
+		},
+
+		DomainsListener:     domainsListener,
+		NonHTTPSRedirectURL: nonHTTPSBackend.URL,
+		ProxyAddress:        ts.URL,
+	})
+	if err != nil {
+		t.Fatalf("listening err: %v", err)
+	}
+	defer lc.Close()
+
+	tests := [...]struct {
+		url     string
+		wantLog string
+		wantErr bool
+	}{
+		0: {
+			url:     "http://git.orijtech.com",
+			wantLog: fmt.Sprintf(`first redirected from "http://git.orijtech.com"\nNow at %q`, ts.URL),
+		},
+		1: {
+			url:     "https://repo.orijtech.com",
+			wantLog: fmt.Sprintf("Now at %q\n", ts.URL),
+		},
+	}
+
+	for i, tt := range tests {
+		res, err := ts.Client().Get(tt.url)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d expected non-nil error", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d: err: %v", i, err)
+			continue
+		}
+
+		if res == nil {
+			t.Errorf("#%d: expected non-nil response", i)
+			continue
+		}
+		gotBytes, _ := ioutil.ReadAll(theLog)
+		theLog.Reset()
+
+		want, got := tt.wantLog, string(gotBytes)
+		if want != got {
+			t.Errorf("#%d:\n\tgot:  %q\n\twant: %q", i, got, want)
+		}
+	}
+}
+
+func TestRequestValidate(t *testing.T) {
+	tests := [...]struct {
+		req     *frontender.Request
+		wantErr bool
+	}{
+		0: {req: nil, wantErr: true},
+		1: {req: &frontender.Request{}, wantErr: true},
+		2: {
+			req: &frontender.Request{
+				Domains:      []string{"golang.org/"},
+				ProxyAddress: "http://192.168.1.104/",
+			},
+		},
+		3: {
+			req: &frontender.Request{
+				Domains: []string{"orijtech.com/"},
+			},
+			// No proxy address specified.
+			wantErr: true,
+		},
+	}
+
+	for i, tt := range tests {
+		err := tt.req.Validate()
+		gotErr := err != nil
+		wantErr := tt.wantErr
+		if gotErr != wantErr {
+			t.Errorf("#%d: gotErr=%v wantErr=%v; err=%v", i, gotErr, wantErr, err)
+		}
+	}
+}
+
+func TestRequestMakeDomains(t *testing.T) {
+	tests := [...]struct {
+		req  *frontender.Request
+		want []string
+	}{
+		0: {
+			req: &frontender.Request{
+				Domains: []string{"foo", "www.foo", "", "foo", "FOO", "www.flux"},
+			},
+			want: []string{
+				"foo",
+				"www.foo",
+				"FOO",
+				"www.FOO",
+				"www.flux",
+			},
+		},
+
+		1: {
+			req: &frontender.Request{
+				Domains:   []string{"foo", "", "foo", "FOO", "www.flux"},
+				NoAutoWWW: true,
+			},
+			want: []string{
+				"foo",
+				"FOO",
+				"www.flux",
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		got := tt.req.SynthesizeDomains()
+		want := tt.want
+
+		// Sort them both for proper comparison
+		sort.Strings(got)
+		sort.Strings(want)
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("#%d:\ngot:  %#v\nwant: %#v\n", i, got, want)
+		}
+	}
+}

--- a/gen.go
+++ b/gen.go
@@ -1,0 +1,288 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontender
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/odeke-em/go-uuid"
+)
+
+var errUnimplemented = errors.New("unimplemented")
+
+// Goal: Generate the binary so that it can be deployed as a disk image or a Dockerfile.
+
+type DeployInfo struct {
+	FrontendConfig *Request
+	SourceImage    string
+	ImageName      string
+
+	TargetGOOS string
+	Environ    []string
+
+	CanonicalImageName       string `json:"canonical_image_name"`
+	CanonicalImageNamePrefix string `json:"canonical_image_name_prefix"`
+}
+
+func GenerateDockerImageForGCE(req *DeployInfo) (imageName string, err error) {
+	return "", errUnimplemented
+}
+
+type BinaryHandle struct {
+	done      func() error
+	rc        io.ReadCloser
+	path      string
+	binDir    string
+	closeOnce sync.Once
+}
+
+func (bh *BinaryHandle) Read(b []byte) (int, error) {
+	return bh.rc.Read(b)
+}
+
+func (bh *BinaryHandle) Close() error {
+	var err error = io.EOF
+	bh.closeOnce.Do(func() {
+		err = bh.rc.Close()
+		if bh.done != nil {
+			e := bh.done()
+			if err == nil {
+				err = e
+			}
+		}
+	})
+	return err
+}
+
+var _ io.ReadCloser = (*BinaryHandle)(nil)
+
+func GenerateBinary(req *DeployInfo) (io.ReadCloser, error) {
+	return generateBinary(req)
+}
+
+func generateBinary(req *DeployInfo) (*BinaryHandle, error) {
+	// 1. Generate the main.go file:
+	binDir := fmt.Sprintf("./bin/%s", uuid.NewRandom())
+	if err := os.MkdirAll(binDir, 0777); err != nil {
+		return nil, err
+	}
+	abort := func() error { return os.RemoveAll(binDir) }
+
+	goMainFilepath := filepath.Join(binDir, "main.go")
+	f, err := os.Create(goMainFilepath)
+	if err != nil {
+		abort()
+		return nil, err
+	}
+
+	if err := req.FrontendConfig.Validate(); err != nil {
+		abort()
+		return nil, err
+	}
+
+	err = mainTmpl.Execute(f, req.FrontendConfig)
+	_ = f.Close()
+
+	if err != nil {
+		abort()
+		return nil, err
+	}
+
+	// 2. Next step is to build the binary
+	binaryPath := filepath.Join(binDir, "generated-exec")
+	cmdArgs := []string{"build", "-o", binaryPath, binDir}
+	cmd := exec.Command("go", cmdArgs...)
+
+	// 2.1. Build the environment for the comment
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	if goos := strings.TrimSpace(req.TargetGOOS); goos != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("GOOS=%s", goos))
+	}
+	if len(req.Environ) > 0 {
+		cmd.Env = append(cmd.Env, req.Environ...)
+	}
+
+	if resp, err := cmd.CombinedOutput(); err != nil {
+		if len(bytes.TrimSpace(resp)) > 0 {
+			err = errors.New(string(resp))
+		}
+		abort()
+		return nil, err
+	}
+	f, err = os.Open(binaryPath)
+	if err != nil {
+		abort()
+		return nil, err
+	}
+
+	bh := &BinaryHandle{
+		rc:     f,
+		path:   binaryPath,
+		done:   abort,
+		binDir: binDir,
+	}
+	return bh, nil
+}
+
+func GenerateDockerImage(req *DeployInfo) (imageName string, err error) {
+	// 1. Generate the binary
+	bh, err := generateBinary(req)
+	if err != nil {
+		return "", err
+	}
+	defer bh.Close()
+
+	binDir := bh.binDir
+	binaryPath := bh.path
+
+	// 2. Generate the Dockerfile.
+	dockerFilePath := filepath.Join(binDir, "Dockerfile")
+	dockerFile, err := os.Create(dockerFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	binaryBasePath := filepath.Base(binaryPath)
+	dockerConfig := &DockerConfig{
+		BinaryPath:  binaryBasePath,
+		SourceImage: req.SourceImage,
+		ImageName:   imageNameOrGenerated(req.ImageName),
+	}
+	err = dockerFileTmpl.Execute(dockerFile, dockerConfig)
+	_ = dockerFile.Close()
+	if err != nil {
+		return "", err
+	}
+
+	canonicalImageName := ensureCanonicalImage(req)
+	dockerBuildArgs := []string{"build", "-t", canonicalImageName, binDir}
+	cmd := exec.Command("docker", dockerBuildArgs...)
+	if resp, err := cmd.CombinedOutput(); err != nil {
+		if len(bytes.TrimSpace(resp)) > 0 {
+			err = errors.New(string(resp))
+		}
+		return "", err
+	}
+
+	return canonicalImageName, nil
+}
+
+func ensureCanonicalImage(req *DeployInfo) string {
+	if name := req.CanonicalImageName; name != "" {
+		return name
+	}
+	suffix := fmt.Sprintf("generated-%d", time.Now().Unix())
+	if req.CanonicalImageNamePrefix == "" {
+		return suffix
+	}
+	return req.CanonicalImageNamePrefix + "/" + suffix
+}
+
+type Dependency struct {
+	LocalPath  string
+	DockerPath string
+}
+
+type DockerConfig struct {
+	PrerunCommands []string      `json:"prerun_commands"`
+	Dependencies   []*Dependency `json:"dependencies"`
+	ImageName      string        `json:"image_name"`
+	SourceImage    string        `json:"source_image"`
+	BinaryPath     string        `json:"binary_path"`
+}
+
+const dockerFileBody = `
+from {{imageOrDefault .SourceImage}}
+
+ADD {{.BinaryPath}} {{.ImageName}}
+
+{{range .Dependencies}}
+ADD {{.LocalPath}} {{.DockerPath}}
+{{end}}
+{{if .PrerunCommands}}{{range .PrerunCommands}}CMD ["{{.}}"]{{end}}{{end}}
+
+CMD ["./{{.ImageName}}"]
+`
+
+func imageNameOrGenerated(img string) string {
+	if img != "" {
+		return img
+	}
+	return fmt.Sprintf("%s-generated", uuid.NewRandom())
+}
+
+var funcs = template.FuncMap{
+	"gobEncodeAndQuote": func(v interface{}) string {
+		buf := new(bytes.Buffer)
+		_ = gob.NewEncoder(buf).Encode(v)
+		return strconv.Quote(string(buf.Bytes()))
+	},
+
+	"imageNameOrGenerated": imageNameOrGenerated,
+
+	"imageOrDefault": func(imageName string) string {
+		if imageName == "" {
+			return "debian:jessie"
+		} else {
+			return imageName
+		}
+	},
+}
+
+var (
+	mainTmpl       = template.Must(template.New("mainTmpl").Funcs(funcs).Parse(mainBody))
+	dockerFileTmpl = template.Must(template.New("dockerfile").Funcs(funcs).Parse(dockerFileBody))
+)
+
+const mainBody = `
+package main
+
+import (
+	"log"
+	"encoding/gob"
+	"strings"
+
+	"github.com/orijtech/frontender"
+)
+
+func main() {
+	buf := strings.NewReader({{gobEncodeAndQuote .}})
+	req := new(frontender.Request)
+	if err := gob.NewDecoder(buf).Decode(req); err != nil {
+		log.Fatalf("gobDecoding err: %v", err)
+	}
+	lc, err := frontender.Listen(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer lc.Close()
+
+	if err := lc.Wait(); err != nil {
+		log.Fatal(err)
+	}
+}
+`


### PR DESCRIPTION
OSS'd the code used to quickly spin up HTTPS frontends
that then proxy the traffic to the backends that then
handle the traffic appropriately.
The need came from the repetitive setup of many websites
and needing to detach the frontend that receives traffic
from the actual backend that needs to process the traffic,
and might be a cluster of its own or could be taken down
transparently without having to interrupt the entire website's
flow.

Sample exhibits from [example_test.go](./example_test.go)

Examples:
* Preamble with imports:
```go
package frontender_test

import (
	"io"
	"log"
	"os"

	"github.com/orijtech/frontender"
)
```

* Plain listen as a server:
```go
func listen() {
	lc, err := frontender.Listen(&frontender.Request{
		Domains: []string{
			"git.orijtech.com",
			"repo.orijtech.com",
		},
		NonHTTPSRedirectURL: "https://git.orijtech.com",

		ProxyAddress: "http://localhost:9845",

		NoAutoWWW: true,
	})
	if err != nil {
		log.Fatal(err)
	}
	defer lc.Close()

	if err := lc.Wait(); err != nil {
		log.Fatal(err)
	}
}
```

* Generate the binary of the server for a platform
```go
func generateBinary() {
	rc, err := frontender.GenerateBinary(&frontender.DeployInfo{
		FrontendConfig: &frontender.Request{
			Domains: []string{
				"www.medisa.orijtech.com",
				"medisa.orijtech.com",
				"m.orijtech.com",
			},
			ProxyAddress: "http://192.168.1.105:9855",
		},
		TargetGOOS: "linux",
		Environ:    []string{"CGO_ENABLED=0"},
	})
	if err != nil {
		log.Fatal(err)
	}
	defer rc.Close()

	f, err := os.Create("theBinary")
	if err != nil {
		log.Fatal(err)
	}
	defer f.Close()

	io.Copy(f, rc)
}
```

* Generate a Docker image for the server
```go
func generateDockerImage() {
	imageName, err := frontender.GenerateDockerImage(&frontender.DeployInfo{
		CanonicalImageNamePrefix: "frontender",
		FrontendConfig: &frontender.Request{
			Domains: []string{
				"git.orijtech.com",
				"repo.orijtech.com",
			},
			NonHTTPSRedirectURL: "https://git.orijtech.com",

			ProxyAddress: "http://localhost:9845",

			NoAutoWWW: true,
		},
		ImageName: "odex-auto",
	})
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("ImageName: %q\n", imageName)
}
```