### PR TITLE
liveliness: package to represent backend peers

### DIFF
--- a/frontender.go
+++ b/frontender.go
@@ -156,6 +156,9 @@ func (req *Request) needsDomains() bool {
 	return req.HTTP1 == false
 }
 
+// The goal is to be able to pass in proxy servers, keep a 
+// persistent connection to each one of them and use that
+// as the weight to figure out which one to send traffic to.
 func Listen(req *Request) (*ListenConfirmation, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err

--- a/lively/lively.go
+++ b/lively/lively.go
@@ -1,0 +1,165 @@
+package lively
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/orijtech/otils"
+
+	"github.com/odeke-em/semalim"
+)
+
+type Peer struct {
+	Addr string `json:"addr"`
+	ID   string `json:"id"`
+
+	Primary bool `json:"primary"`
+
+	Peers map[string]*Peer `json:"peers"`
+
+	mu sync.RWMutex
+	rt http.RoundTripper
+}
+
+type Ping struct {
+	PeerID string `json:"id"`
+	Clock  int64  `json:"clock"`
+}
+
+func (e *Peer) ping(other *Peer) (*Ping, error) {
+	blob, err := json.Marshal(&Ping{PeerID: e.ID, Clock: time.Now().Unix()})
+	if err != nil {
+		return nil, err
+	}
+
+	addr := fmt.Sprintf("%s/ping", other.Addr)
+	body := bytes.NewReader(blob)
+	req, err := http.NewRequest("POST", addr, body)
+	if err != nil {
+		return nil, err
+	}
+	res, err := e.httpClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !otils.StatusOK(res.StatusCode) {
+		return nil, errors.New(res.Status)
+	}
+	slurp, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	recv := new(Ping)
+	if err := json.Unmarshal(slurp, recv); err != nil {
+		return nil, err
+	}
+	return recv, nil
+}
+
+func (e *Peer) httpClient() *http.Client {
+	e.mu.RLock()
+	rt := e.rt
+	e.mu.RUnlock()
+
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	return &http.Client{Transport: rt}
+}
+
+func (e *Peer) Consesus() error {
+	return nil
+}
+
+var errBlankPeerID = errors.New("peer has a blank ID")
+
+func (p *Peer) AddPeer(other *Peer) error {
+	otherID := strings.TrimSpace(other.ID)
+	if otherID == "" {
+		return errBlankPeerID
+	}
+
+	p.mu.RLock()
+	if p.Peers == nil {
+		p.Peers = make(map[string]*Peer)
+	}
+	p.Peers[otherID] = other
+	p.mu.RUnlock()
+
+	return nil
+}
+
+func (p *Peer) SetHTTPRoundTripper(rt http.RoundTripper) {
+	p.mu.Lock()
+	p.rt = rt
+	p.mu.Unlock()
+}
+
+type Liveliness struct {
+	PeerID string `json:"peer_id"`
+	Ping   *Ping  `json:"ping"`
+	Err    error  `json:"error"`
+}
+
+type LivelyRequest struct {
+	ConcurrentPings int
+}
+
+func (p *Peer) Liveliness(llv *LivelyRequest) (livePeers, nonLivePeers []*Liveliness, err error) {
+	p.mu.RLock()
+	curPeers := make(map[string]*Peer, len(p.Peers))
+	for id, curPeer := range p.Peers {
+		curPeers[id] = curPeer
+	}
+	p.mu.RUnlock()
+
+	jobsBench := make(chan semalim.Job)
+	go func() {
+		defer close(jobsBench)
+
+		for _, curPeer := range curPeers {
+			jobsBench <- &peerPing{id: curPeer.ID, peer: curPeer, self: p}
+		}
+	}()
+
+	concurrentPings := 5
+	if llv != nil && llv.ConcurrentPings > 0 {
+		concurrentPings = llv.ConcurrentPings
+	}
+	resChan := semalim.Run(jobsBench, uint64(concurrentPings))
+	for res := range resChan {
+		pping := res.Value().(*Ping)
+		peerID := res.Id().(string)
+		err := res.Err()
+		ptr := &nonLivePeers
+		if err == nil && pping != nil {
+			ptr = &livePeers
+		}
+		*ptr = append(*ptr, &Liveliness{Err: err, PeerID: peerID, Ping: pping})
+	}
+
+	return livePeers, nonLivePeers, nil
+}
+
+type peerPing struct {
+	id   string
+	peer *Peer
+	self *Peer
+}
+
+var _ semalim.Job = (*peerPing)(nil)
+
+func (pp *peerPing) Id() interface{} {
+	return pp.id
+}
+
+func (pp *peerPing) Do() (interface{}, error) {
+	return pp.self.ping(pp.peer)
+}

--- a/lively/lively_test.go
+++ b/lively/lively_test.go
@@ -1,0 +1,135 @@
+package lively_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/orijtech/frontender/lively"
+
+	"github.com/odeke-em/go-uuid"
+)
+
+func TestLiveliness(t *testing.T) {
+	baseAddr := "http://192.168.1.68"
+	peers := nPeers(64, baseAddr)
+
+	// Arbitrarily pick the first as the primary
+	primaryIndex := 0
+
+	for i := 0; i < 20; i++ {
+		blockedIndices := rand.Perm(len(peers) / 2)
+		blockedMap := make(map[string]bool)
+		for _, blockedIndex := range blockedIndices {
+			blockedPeer := peers[blockedIndex]
+			blockedMap[blockedPeer.ID] = true
+		}
+
+		primary := peers[primaryIndex]
+		primary.Primary = true
+
+		// Next make the rest the peers for the primary
+		secondaries := append(peers[:primaryIndex], peers[primaryIndex+1:]...)
+		for _, secondary := range secondaries {
+			primary.AddPeer(secondary)
+			secondary.AddPeer(primary)
+			secondary.Primary = false
+		}
+
+		var updatedPeers []*lively.Peer
+		for _, peer := range peers {
+			peer.SetHTTPRoundTripper(&backend{id: peer.ID, blocked: blockedMap})
+			updatedPeers = append(updatedPeers, peer)
+		}
+		doneChan := make(chan *peerDesc)
+		waitCount := 0
+		// Now asynchronously ping each one of them
+		for i, peer := range peers {
+			waitCount += 1
+			go func(id int) {
+				_, _, err := peer.Liveliness(nil)
+				doneChan <- &peerDesc{i: id, err: err}
+			}(i)
+		}
+
+		for i := 0; i < waitCount; i++ {
+			desc := <-doneChan
+			if err := desc.err; err != nil {
+				t.Errorf("#%d: err: %v", i, err)
+			}
+		}
+	}
+}
+
+type peerDesc struct {
+	i   int
+	err error
+}
+
+// backend is the test roundTripper that mimicks a
+// backend that performs a request and responds with a result.
+type backend struct {
+	blocked map[string]bool
+
+	id string
+}
+
+var blankPtrPing = new(lively.Ping)
+
+func (b *backend) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil || req.Method != "POST" {
+		return makeResp(`expecting "POST" as a method`, http.StatusBadRequest, nil), nil
+	}
+	// Expecting a ping frame
+	slurp, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	recv := new(lively.Ping)
+	if err := json.Unmarshal(slurp, recv); err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	if reflect.DeepEqual(recv, blankPtrPing) {
+		return makeResp(`expecting a non-blank "ping"`, http.StatusBadRequest, nil), nil
+	}
+	if _, blocked := b.blocked[recv.PeerID]; blocked {
+		return makeResp(`purposefully not responding`, http.StatusInternalServerError, nil), nil
+	}
+
+	// Otherwise now respond
+	blob, err := json.Marshal(&lively.Ping{PeerID: b.id, Clock: time.Now().Unix()})
+	if err != nil {
+		return makeResp(err.Error(), http.StatusBadRequest, nil), nil
+	}
+	prc, pwc := io.Pipe()
+	go func() {
+		defer pwc.Close()
+		pwc.Write(blob)
+	}()
+	return makeResp("200 OK", http.StatusOK, prc), nil
+}
+
+func nPeers(n int, baseAddr string) (peers []*lively.Peer) {
+	for i := 0; i < n; i++ {
+		peers = append(peers, &lively.Peer{
+			ID:   uuid.NewRandom().String(),
+			Addr: fmt.Sprintf("%s:%d", baseAddr, i+1000),
+		})
+	}
+	return peers
+}
+
+func makeResp(status string, code int, body io.ReadCloser) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Status:     status,
+		Body:       body,
+		Header:     make(http.Header),
+	}
+}


### PR DESCRIPTION
For any backend server to primary connection, represent
it with a convenience model that will be used by the frontend
when proxying requests to each backend.

Periodically, per cycle, the primary will perform a /ping to
each backend server and then figure out who is alive and who isn't,
then proxy traffic only to those alive until the next cycle
for which the process will repeat.