### PR TITLE
load-distribution: implement proxying to multiple backends

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -30,7 +30,11 @@ func Example_Listen() {
 		},
 		NonHTTPSRedirectURL: "https://git.orijtech.com",
 
-		ProxyAddress: "http://localhost:9845",
+		ProxyAddresses: []string{
+			"http://localhost:9845",
+			"http://localhost:8888",
+			"http://localhost:4447",
+		},
 
 		NoAutoWWW: true,
 	})
@@ -52,7 +56,10 @@ func Example_GenerateBinary() {
 				"medisa.orijtech.com",
 				"m.orijtech.com",
 			},
-			ProxyAddress: "http://192.168.1.105:9855",
+			ProxyAddresses: []string{
+				"http://192.168.1.105:9855",
+				"http://192.168.1.140:8998",
+			},
 		},
 		TargetGOOS: "linux",
 		Environ:    []string{"CGO_ENABLED=0"},
@@ -81,7 +88,10 @@ func Example_GenerateDockerImage() {
 			},
 			NonHTTPSRedirectURL: "https://git.orijtech.com",
 
-			ProxyAddress: "http://localhost:9845",
+			ProxyAddresses: []string{
+				"http://localhost:9845",
+				"http://192.168.1.100:9845",
+			},
 
 			NoAutoWWW: true,
 		},

--- a/frontender_test.go
+++ b/frontender_test.go
@@ -56,7 +56,7 @@ func TestListen(t *testing.T) {
 
 		DomainsListener:     domainsListener,
 		NonHTTPSRedirectURL: nonHTTPSBackend.URL,
-		ProxyAddress:        ts.URL,
+		ProxyAddresses:      []string{ts.URL},
 	})
 	if err != nil {
 		t.Fatalf("listening err: %v", err)
@@ -115,8 +115,11 @@ func TestRequestValidate(t *testing.T) {
 		1: {req: &frontender.Request{}, wantErr: true},
 		2: {
 			req: &frontender.Request{
-				Domains:      []string{"golang.org/"},
-				ProxyAddress: "http://192.168.1.104/",
+				Domains: []string{"golang.org/"},
+				ProxyAddresses: []string{
+					"http://192.168.1.104/",
+					"http://localhost:9999/",
+				},
 			},
 		},
 		3: {


### PR DESCRIPTION
Integrated package ./lively so that the frontend server
can distribute load to multiple backends, but periodically
it can also figure out which servers are live and which aren't
thereby maintaining liveliness and directing to traffic to
those that can receive it, per cycle.
For starters during a cycle, the load is distributed to
live backends in round robin style. However, at the end of every
cycle, the live backends list is recompiled, shuffled(for some fairness)
and then the round robin distribution starts again.