### PR TITLE
cmd/frontender: CLI started + hooked up with lively

### DIFF
--- a/cmd/frontender/README.md
+++ b/cmd/frontender/README.md
@@ -1,0 +1,25 @@
+## frontender
+
+Commandline interface app for the frontender service
+
+## Installation
+```shell
+$ go get github.com/orijtech/frontender/cmd/frontender
+```
+
+## Usage
+- [X] Get the URLs for your backend servers
+- [X] Figure out what domains your frontend's identity will take on e.g
+rsp.orijtech.com, code.orijtech.com -- this is optional if you are running
+frontender as a local non-HTTPS server
+
+### Sample usage serving in production
+```shell
+$ frontender -csv-backends http://localhost:8889,http://localhost:8998,http://localhost:8994 -backend-ping-period 8m -domains orijtech.com,code.orijtech.com,home.orijtech.com
+```
+
+### Sample usage serving locally as non-HTTPS
+```
+$ frontender -csv-backends http://localhost:8889,http://localhost:8998,http://localhost:8994 -backend-ping-period 2m -http1
+```
+

--- a/cmd/frontender/main.go
+++ b/cmd/frontender/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/orijtech/frontender"
+)
+
+func main() {
+	var http1 bool
+	var csvBackendAddresses string
+	var nonHTTPSAddr string
+	var backendPingPeriodStr string
+	var csvDomains string
+	var noAutoWWW bool
+	var nonHTTPSRedirectURL string
+
+	flag.StringVar(&csvBackendAddresses, "csv-backends", "", "the comma separated addresses of the backend servers")
+	flag.StringVar(&csvDomains, "domains", "", "the comma separated domains that the frontend will be representing")
+	flag.BoolVar(&http1, "http1", false, "if true signals that the server should run as an http1 server locally")
+	flag.StringVar(&nonHTTPSAddr, "non-https-addr", ":8877", "the non-https address")
+	flag.StringVar(&nonHTTPSRedirectURL, "non-https-redirect", "", "the URL to which all non-HTTPS traffic will be redirected")
+	flag.BoolVar(&noAutoWWW, "no-auto-www", false, "if set, explicits tells the frontend service NOT to make equivalent www CNAMEs of domains, if the www CNAMEs haven't yet been set")
+	flag.StringVar(&backendPingPeriodStr, "backend-ping-period", "3m", `the period for which the frontend should ping the backend servers. Please enter this value with the form <DIGIT><UNIT> where <UNIT> could be  "ns", "us" (or "µs"), "ms", "s", "m", "h"`)
+	flag.Parse()
+
+	var pingPeriod time.Duration
+	if t, err := time.ParseDuration(backendPingPeriodStr); err == nil {
+		pingPeriod = t
+	}
+
+	fReq := &frontender.Request{
+		HTTP1:   http1,
+		Domains: splitAndTrimAddresses(csvDomains),
+
+		NoAutoWWW:           noAutoWWW,
+		NonHTTPSAddr:        nonHTTPSAddr,
+		NonHTTPSRedirectURL: nonHTTPSRedirectURL,
+
+		ProxyAddresses:    splitAndTrimAddresses(csvBackendAddresses),
+		BackendPingPeriod: pingPeriod,
+	}
+
+	confirmation, err := frontender.Listen(fReq)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer confirmation.Close()
+
+	if err := confirmation.Wait(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func splitAndTrimAddresses(csvOfAddresses string) []string {
+	splits := strings.Split(csvOfAddresses, ",")
+	var trimmed []string
+	for _, split := range splits {
+		trimmed = append(trimmed, strings.TrimSpace(split))
+	}
+	return trimmed
+}


### PR DESCRIPTION
* Made a CLI that can now be runnable by anyone
* Hooked up frontender with the liveliness check package
and performed an end to end test
* Made an exception for easy compatibility with older(and most)
systems because not everyone is going to want to have to go change
their code base to include a /ping route just to use this server.
The exception now is that if lively encounters a 404 Not Found,
we know the backend server is alive and can therefore mark it
as lively since it actually responded.