### PR TITLE
lively: ensure ping closes body irrespective of status code

### DIFF
--- a/frontender.go
+++ b/frontender.go
@@ -124,16 +124,6 @@ func (req *Request) SynthesizeDomains() []string {
 	return finalList
 }
 
-type proxy struct {
-	proxyAddress string
-}
-
-func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, p.proxyAddress, http.StatusPermanentRedirect)
-}
-
-var _ http.Handler = (*proxy)(nil)
-
 func (req *Request) runNonHTTPSRedirector() error {
 	if req.HTTP1 {
 		return nil

--- a/lively/lively.go
+++ b/lively/lively.go
@@ -51,6 +51,9 @@ func (e *Peer) ping(other *Peer) (*Ping, error) {
 	if err != nil {
 		return nil, err
 	}
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
 	if !otils.StatusOK(res.StatusCode) {
 		// There is an exception::
 		// 1) Not every backend service is bound to have a /ping route defined


### PR DESCRIPTION
Ensure that ping closes its response body irrespective of
status code. I noticed this while investigating a test
deployment using frontender as the frontend server on
Google Compute Engine and noticed a bunch of leaks.
Added a test to ensure that we always close the response body
irrespective of status code, as long as it is non-nil.