### PR TITLE
ignore unmarshal errors from ping, avoid nil roundRobinAddress

### DIFF
--- a/frontender.go
+++ b/frontender.go
@@ -265,6 +265,9 @@ func (lp *livelyProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (lp *livelyProxy) roundRobinedAddress() string {
 	lp.mu.Lock()
+	if len(lp.liveAddresses) == 0 {
+		return ""
+	}
 	if lp.next >= len(lp.liveAddresses) {
 		lp.next = 0
 	}

--- a/lively/lively.go
+++ b/lively/lively.go
@@ -72,9 +72,8 @@ func (e *Peer) ping(other *Peer) (*Ping, error) {
 		return nil, err
 	}
 	recv := new(Ping)
-	if err := json.Unmarshal(slurp, recv); err != nil {
-		return nil, err
-	}
+	// We don't really care about the error returned
+	_ = json.Unmarshal(slurp, recv)
 	return recv, nil
 }
 


### PR DESCRIPTION
* Many backends won't implement a compliant
/ping endpoint. As long as we get back some
sort of liveliness indicator about the backend
server, that's good enough to show that
the endpoint is reachable.

* Avoid nil dereferencing next address
if there are no liveAddresses available.